### PR TITLE
fix: 修正されたルーターのプロバイダー設定

### DIFF
--- a/taskScheduler/src/main.ts
+++ b/taskScheduler/src/main.ts
@@ -3,12 +3,13 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { SchedulePage } from './app/page/schedule/schedule.page';
 import { routes } from './app/app.routes';
 import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 import { SCHEDULE_SERVICE } from './app/di/tokens';
 import { MockScheduleService } from './app/domain/service/impl/mock-schedule.service';
 
 bootstrapApplication(SchedulePage, {
   providers: [
-    routes,
+    provideRouter(routes),
     provideHttpClient(),
     { provide: SCHEDULE_SERVICE, useExisting: MockScheduleService },
   ],


### PR DESCRIPTION
## Summary
- ルート定義を正しく提供するためprovideRouterを使用

## Testing
- `npm test -- --watch=false` *(失敗: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6898af151e7c8331a776eb5dcf5242e1